### PR TITLE
Add `contains`, improve filtering MySQL-style WKB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '8.1'
-          tools: 'composer, phpstan'
+          tools: 'composer'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -80,5 +80,4 @@ jobs:
         run: 'composer install --prefer-dist --no-interaction'
 
       - name: 'Run PHP STAN'
-        run: |
-          phpstan analyse --no-progress src
+        run: 'composer run-script stan'

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.2",
-        "phpunit/phpunit": "^8.5 || ^9.3"
+        "phpunit/phpunit": "^8.5 || ^9.3",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,12 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+  phpVersion: 70400
+  level: 4
+  ignoreErrors:
+    - message: '#Call to static method map\(\) on an unknown class Cake\\Database\\Type.#'
+      paths:
+        - src/Plugin.php

--- a/src/Geometry.php
+++ b/src/Geometry.php
@@ -35,7 +35,7 @@ class Geometry implements \JsonSerializable
      *
      * @param \Brick\Geo\Geometry $geometry The geometry instance.
      */
-    public function __construct(BrickGeometry $geometry)
+    final public function __construct(BrickGeometry $geometry)
     {
         $this->geometry = $geometry;
     }
@@ -63,7 +63,7 @@ class Geometry implements \JsonSerializable
                 // Not a WKB string.
             }
 
-            if (strlen($geometry) > 4) {
+            if (strspn($geometry, '01', 0, 4) === 4) {
                 try {
                     [$wkb, $srid] = [substr($geometry, 4), bindec(substr($geometry, 0, 4))];
 

--- a/src/Model/Behavior/GeometryBehavior.php
+++ b/src/Model/Behavior/GeometryBehavior.php
@@ -46,7 +46,7 @@ class GeometryBehavior extends Behavior
      */
     public function findGeo(Query $query, array $options): Query
     {
-        $options = array_intersect_key($options, array_flip(['intersects', 'within']));
+        $options = array_intersect_key($options, array_flip(['intersects', 'within', 'contains']));
 
         $dbField = $this->_table->aliasField($this->getConfigOrFail('geometryField'));
         $dbGeom = [$dbField => 'identifier'];
@@ -83,6 +83,16 @@ class GeometryBehavior extends Behavior
                         ->isNotNull($dbField)
                         ->notEq($dbField, '', 'string')
                         ->add(new FunctionExpression('ST_Within', array_merge($dbGeom, ['test' => $geom]), ['test' => 'geometry'])));
+
+                    break;
+
+                case 'contains':
+                    $geom = Geometry::parse($geom)->getGeometry()->withSRID(0);
+
+                    $query = $query->where(fn (QueryExpression $exp) => $exp
+                        ->isNotNull($dbField)
+                        ->notEq($dbField, '', 'string')
+                        ->add(new FunctionExpression('ST_Contains', array_merge($dbGeom, ['test' => $geom]), ['test' => 'geometry'])));
 
                     break;
             }


### PR DESCRIPTION
This MR introduces the capability for `->filter('geo', ['contains' => $geometry])`. Also, it improves how the check for SRID-prefixed WKB is performed, which should avoid a few deprecation errors.