### PR TITLE
Add `mixed` return type to `jsonSerialize`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,14 @@
     "type": "cakephp-plugin",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
-        "cakephp/cakephp": "^3.10 || ^4.2",
+        "php": "^8.0",
+        "ext-json": "*",
+        "cakephp/cakephp": "^4.2",
         "brick/geo": "^0.7.1"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^4.2",
-        "phpunit/phpunit": "^8.5 || ^9.3",
+        "cakephp/cakephp-codesniffer": "^5.1",
+        "phpunit/phpunit": "^9.3",
         "phpstan/phpstan": "^1.10"
     },
     "autoload": {
@@ -29,8 +30,8 @@
             "@test",
             "@cs-check"
         ],
-        "cs-check": "phpcs --colors -p src/ tests/",
-        "cs-fix": "phpcbf --colors -p src/ tests/",
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
         "stan": "phpstan analyse",
         "test": "phpunit --colors=always"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <ruleset name="App">
+    <file>./src</file>
+    <file>./tests</file>
+
+    <arg name="colors" />
+    <arg value="p" />
+
     <config name="installed_paths" value="../../cakephp/cakephp-codesniffer"/>
 
     <rule ref="CakePHP"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,9 +4,5 @@ parameters:
   paths:
     - src
     - tests
-  phpVersion: 70400
+  phpVersion: 80000
   level: 4
-  ignoreErrors:
-    - message: '#Call to static method map\(\) on an unknown class Cake\\Database\\Type.#'
-      paths:
-        - src/Plugin.php

--- a/src/Database/Type/GeometryType.php
+++ b/src/Database/Type/GeometryType.php
@@ -34,7 +34,7 @@ class GeometryType implements TypeInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getName(): string
     {
@@ -42,7 +42,7 @@ class GeometryType implements TypeInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function getBaseType(): string
     {
@@ -55,13 +55,13 @@ class GeometryType implements TypeInterface
      * @param mixed $value The value to check.
      * @return bool
      */
-    protected static function isNullGeometry($value): bool
+    protected static function isNullGeometry(mixed $value): bool
     {
         return $value === null || $value === '';
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function toDatabase($value, DriverInterface $driver): ?string
     {
@@ -79,7 +79,7 @@ class GeometryType implements TypeInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function toPHP($value, DriverInterface $driver): ?Geometry
     {
@@ -91,7 +91,7 @@ class GeometryType implements TypeInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function toStatement($value, DriverInterface $driver): int
     {
@@ -103,7 +103,7 @@ class GeometryType implements TypeInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function marshal($value): ?Geometry
     {
@@ -115,7 +115,7 @@ class GeometryType implements TypeInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     public function newId(): ?string
     {

--- a/src/Geometry.php
+++ b/src/Geometry.php
@@ -104,7 +104,7 @@ class Geometry implements \JsonSerializable
      *
      * @return mixed The serialized geometry.
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         switch (static::$serializeAs) {
             case 'wkb':

--- a/src/Geometry.php
+++ b/src/Geometry.php
@@ -14,11 +14,12 @@ use Brick\Geo\IO\WKBReader;
 use Brick\Geo\IO\WKBWriter;
 use Brick\Geo\IO\WKTWriter;
 use InvalidArgumentException;
+use JsonSerializable;
 
 /**
  * Serializable Geometry wrapper.
  */
-class Geometry implements \JsonSerializable
+class Geometry implements JsonSerializable
 {
     /**
      * The brick geometry instance.
@@ -46,7 +47,7 @@ class Geometry implements \JsonSerializable
      * @param mixed $geometry Geometry.
      * @return static
      */
-    public static function parse($geometry): self
+    public static function parse(mixed $geometry): self
     {
         if ($geometry instanceof static) {
             return clone $geometry;
@@ -133,7 +134,7 @@ class Geometry implements \JsonSerializable
      *
      * @return array
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         return [
             'type' => $this->geometry->geometryType(),

--- a/src/Model/Behavior/GeometryBehavior.php
+++ b/src/Model/Behavior/GeometryBehavior.php
@@ -8,6 +8,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 use Chialab\Geometry\Geometry;
+use RuntimeException;
 
 /**
  * Geometry behavior
@@ -62,7 +63,7 @@ class GeometryBehavior extends Behavior
                 $dbGeom = [new FunctionExpression('ST_GeomFromWKB', $dbGeom)];
                 break;
             default:
-                throw new \RuntimeException('Invalid geometry storage format');
+                throw new RuntimeException('Invalid geometry storage format');
         }
 
         foreach ($options as $op => $geom) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,7 +5,6 @@ namespace Chialab\Geometry;
 
 use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
-use Cake\Database\Type;
 use Cake\Database\TypeFactory;
 use Chialab\Geometry\Database\Type\GeometryType;
 
@@ -21,12 +20,6 @@ class Plugin extends BasePlugin
     {
         parent::bootstrap($app);
 
-        if (class_exists(TypeFactory::class)) {
-            // CakePHP 4.x
-            TypeFactory::map('geometry', GeometryType::class);
-        } else {
-            // CakePHP 3.x
-            Type::map('geometry', GeometryType::class);
-        }
+        TypeFactory::map('geometry', GeometryType::class);
     }
 }


### PR DESCRIPTION
This MR fixes a warning with the latest PHP versions, requiring `JsonSerializable::jsonSerialize()` to declare a return type `mixed`.

Due to this, the requirements have been bumped to PHP 8.x and CakePHP 4. Version 0.4 should be released after this PR is accepted.